### PR TITLE
Notify about deprecation of the project

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Notify Workflow Completed GitHub Action
 
+:warning: **This project is DEPRECATED.** The action has been moved to [the keep-network/ci repository](https://github.com/keep-network/ci/tree/main/actions/notify-workflow-completed)!
+
 This is a GitHub Action that notifies release management workflow about a workflow
 completion.
 


### PR DESCRIPTION
The actions that depend on the `keep-network/ci/config/config.json` file
have been moved to the `ci` repository to make updates of the CI cycle
easier to apply.